### PR TITLE
Enabling test coverage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'android-apt'
 apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'me.tatarka.retrolambda'
+apply from: './coverage.gradle'
 
 android {
   compileSdkVersion 23

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'jacoco'
+
+afterEvaluate { project ->
+
+    project.android.productFlavors.each { flavor ->
+
+        def jacocoRetrolambdaMap = [:]
+
+        project.android.buildTypes.each { type ->
+
+            task "jacoco${flavor.name.capitalize()}${type.name.capitalize()}TestReport"(type: JacocoReport, dependsOn: "test${flavor.name.capitalize()}${type.name.capitalize()}UnitTest") {
+
+                reports {
+                    xml.enabled = true
+                    html.enabled = true
+                }
+
+                jacocoClasspath = configurations['androidJacocoAnt']
+
+                def fileFilter = ['**/Dagger*.class', '**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+                def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/${flavor.name}/${type.name}", excludes: fileFilter)
+                def mainSrc = "${project.projectDir}/src/main/java"
+
+                sourceDirectories = files([mainSrc])
+                classDirectories = files([debugTree])
+                executionData = files("${buildDir}/jacoco/test${flavor.name.capitalize()}${type.name.capitalize()}UnitTest.exec")
+
+                // Small workaround for coverage on Retrolambda class files
+                doFirst {
+                    new File("${buildDir}/intermediates/classes/${flavor.name}/${type.name}").eachFileRecurse { file ->
+                        if (file.name.contains('$$')) {
+                            def renamed = file.path.replace '$$', '$'
+                            jacocoRetrolambdaMap[renamed] = file.path
+                            file.renameTo renamed
+                        }
+                    }
+                }
+
+                doLast {
+                    // Revert renamed files back to their generated names
+                    jacocoRetrolambdaMap.each { renamed, original ->
+                        new File(renamed).renameTo original
+                    }
+                    println "JaCoCo report has been generated to file://${reports.html.destination}/index.html"
+                }
+            }
+        }
+    }
+
+    task jacocoTestReport(dependsOn: project.android.buildTypes.collect {
+        def type = it.name
+        project.android.productFlavors.collect {
+            "jacoco${it.name.capitalize()}${type.capitalize()}TestReport"
+        }
+    })
+}


### PR DESCRIPTION
This PR enables test coverage from unit tests execution data through `jacocoTestReport` task of, if you want to generate the coverage of a single combination of flavor / build variant, you can execute `jacocoDevDebugTestReport`.