### PR TITLE
Do not calculate MatchResults eagerly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
   buildTypes {
     debug {
-      buildConfigField "String", "API_ENDPOINT", "\"$devApiEndpoint\""
+      buildConfigField "String", "API_ENDPOINT", "\"$prodApiEndpoint\""
     }
     release {
       buildConfigField "String", "API_ENDPOINT", "\"$prodApiEndpoint\""

--- a/app/src/main/java/com/felipecsl/elifut/DataModule.java
+++ b/app/src/main/java/com/felipecsl/elifut/DataModule.java
@@ -78,12 +78,16 @@ public class DataModule {
   }
 
   @Provides @Singleton LeagueRoundGenerator provideLeagueRoundGenerator() {
-    return new LeagueRoundGenerator(new MatchResultGenerator());
+    return new LeagueRoundGenerator();
   }
 
-  @Provides @Singleton LeagueDetails provideLeaguePreferences(
-      ElifutDataStore persistenceService, LeagueRoundGenerator leagueRoundGenerator) {
-    return new LeagueDetails(persistenceService, leagueRoundGenerator);
+  @Provides @Singleton MatchResultGenerator provideMatchResultGenerator() {
+    return new MatchResultGenerator();
+  }
+
+  @Provides @Singleton LeagueDetails provideLeagueDetails(ElifutDataStore persistenceService,
+      LeagueRoundGenerator leagueRoundGenerator, MatchResultGenerator matchResultGenerator) {
+    return new LeagueDetails(persistenceService, leagueRoundGenerator, matchResultGenerator);
   }
 
   @Provides @Singleton ElifutDataStore provideElifutPersistenceService(

--- a/app/src/main/java/com/felipecsl/elifut/activitiy/NavigationActivity.java
+++ b/app/src/main/java/com/felipecsl/elifut/activitiy/NavigationActivity.java
@@ -170,7 +170,7 @@ public abstract class NavigationActivity extends ElifutActivity
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP) @OnClick(R.id.fab) public void onClickFab() {
-    LeagueRound round = leagueDetails.nextRound();
+    LeagueRound round = leagueDetails.executeRound(leagueDetails.nextRound());
     circularRevealOverlay.setVisibility(View.VISIBLE);
     int distFromEdge = fabMargin + (fab.getWidth() / 2);
     int cx = drawerLayout.getWidth() - distFromEdge;

--- a/app/src/main/java/com/felipecsl/elifut/fragment/TeamSquadFragment.java
+++ b/app/src/main/java/com/felipecsl/elifut/fragment/TeamSquadFragment.java
@@ -59,6 +59,7 @@ public class TeamSquadFragment extends ElifutFragment {
   @Bind(R.id.player_at3) FrameLayout at3;
   @Bind(R.id.player_at4) FrameLayout at4;
 
+  private boolean hasSavedState;
   private final Observer<ClubSquad> playersObserver = new Observer<ClubSquad>() {
     @Override public void onCompleted() {
     }
@@ -86,33 +87,39 @@ public class TeamSquadFragment extends ElifutFragment {
     ButterKnife.bind(this, v);
     daggerComponent().inject(this);
 
-    if (savedInstanceState == null) {
-      club = getArguments().getParcelable(EXTRA_CLUB);
-      loadPlayers();
-    } else {
-      onPlayersLoaded();
-    }
+    hasSavedState = savedInstanceState != null;
 
     return v;
+  }
+
+  @Override public void setUserVisibleHint(boolean isVisibleToUser) {
+    super.setUserVisibleHint(isVisibleToUser);
+    if (isVisibleToUser) {
+      if (!hasSavedState) {
+        club = getArguments().getParcelable(EXTRA_CLUB);
+        loadPlayers();
+      } else {
+        onPlayersLoaded();
+      }
+    }
   }
 
   private void onPlayersLoaded() {
     FluentIterable<Player> defenders = defenders();
     FluentIterable<Player> midfielders = midfielders();
     FluentIterable<Player> attackers = attackers();
-    FluentIterable<Player> cbs = defenders.filter(p -> p.position().equals("CB"));
 
-    loadPlayer(gk, playerByPosition("GK"));
-    loadPlayer(lb, defenders.filter(p -> p.position().equals("LB")).first().get());
-    loadPlayer(cb1, cbs.first().get());
-    loadPlayer(cb2, cbs.last().get());
-    loadPlayer(rb, defenders.filter(p -> p.position().equals("RB")).first().get());
-    loadPlayer(cm1, midfielders.get(0));
-    loadPlayer(cm2, midfielders.get(1));
-    loadPlayer(cm3, midfielders.get(2));
-    loadPlayer(cm4, midfielders.get(3));
-    loadPlayer(at2, attackers.first().get());
-    loadPlayer(at3, attackers.last().get());
+    loadPlayer(gk, playerByPosition("GK"), 200);
+    loadPlayer(lb, defenders.get(0), 220);
+    loadPlayer(cb1, defenders.get(1), 230);
+    loadPlayer(cb2, defenders.get(2), 240);
+    loadPlayer(rb, defenders.get(3), 250);
+    loadPlayer(cm1, midfielders.get(0), 270);
+    loadPlayer(cm2, midfielders.get(1), 280);
+    loadPlayer(cm3, midfielders.get(2), 290);
+    loadPlayer(cm4, midfielders.get(3), 300);
+    loadPlayer(at2, attackers.first().get(), 320);
+    loadPlayer(at3, attackers.last().get(), 330);
   }
 
   private FluentIterable<Player> defenders() {
@@ -143,10 +150,18 @@ public class TeamSquadFragment extends ElifutFragment {
     return FluentIterable.from(players).filter(predicate);
   }
 
-  private void loadPlayer(ViewGroup target, Player player) {
+  private void loadPlayer(ViewGroup target, Player player, long delay) {
     SelectableSmallPlayerViewHolder viewHolder = new SelectableSmallPlayerViewHolder(target, club);
     viewHolder.bind(player);
     target.removeAllViews();
+    viewHolder.itemView.setAlpha(0);
+    viewHolder.itemView.setScaleX(0.8f);
+    viewHolder.itemView.setScaleY(0.8f);
+    viewHolder.itemView.animate()
+        .scaleX(1)
+        .scaleY(1)
+        .setStartDelay(delay)
+        .alpha(1);
     target.addView(viewHolder.itemView);
   }
 

--- a/app/src/main/java/com/felipecsl/elifut/models/Match.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/Match.java
@@ -12,14 +12,23 @@ public abstract class Match implements Parcelable, Persistable {
   @Nullable public abstract Integer id();
   public abstract Club home();
   public abstract Club away();
-  public abstract MatchResult result();
+  // Result is initially null and is only computed when the match is about to start
+  @Nullable public abstract MatchResult result();
 
-  public static Match create(Club home, Club away, MatchResult result) {
-    return create(null, home, away, result);
+  public static Match create(Club home, Club away) {
+    return new AutoValue_Match(null, home, away, null);
   }
 
-  public static Match create(Integer id, Club home, Club away, MatchResult result) {
-    return new AutoValue_Match(id, home, away, result);
+  public static Match create(Integer id, Club home, Club away, MatchResult matchResult) {
+    return new AutoValue_Match(id, home, away, matchResult);
+  }
+
+  public static Match create(Club home, Club away, MatchResult matchResult) {
+    return new AutoValue_Match(null, home, away, matchResult);
+  }
+
+  public static Match create(Integer id, Club home, Club away) {
+    return new AutoValue_Match(id, home, away, null);
   }
 
   @Override public int describeContents() {
@@ -27,13 +36,16 @@ public abstract class Match implements Parcelable, Persistable {
   }
 
   @Override public String toString() {
-    return home().name()
-        + " "
-        + result().homeGoals().size()
-        + " X "
-        + result().awayGoals().size()
-        + " "
-        + away().name();
+    if (result() != null) {
+      return home().name()
+          + " "
+          + result().homeGoals().size()
+          + " X "
+          + result().awayGoals().size()
+          + " "
+          + away().name();
+    }
+    return home().name() + " X " + away().name();
   }
 
   public boolean hasClub(Club club) {
@@ -49,18 +61,21 @@ public abstract class Match implements Parcelable, Persistable {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    Match match = (Match) o;
+    Match matchTwo = (Match) o;
 
-    if (!home().equals(match.home())) return false;
+    if (!home().equals(matchTwo.home())) return false;
     //noinspection SimplifiableIfStatement
-    if (!away().equals(match.away())) return false;
-    return result().equals(match.result());
+    if (!away().equals(matchTwo.away())) return false;
+    //noinspection ConstantConditions
+    return result() != null ? result().equals(matchTwo.result()) : matchTwo.result() == null;
+
   }
 
   @Override public int hashCode() {
     int result1 = home().hashCode();
     result1 = 31 * result1 + away().hashCode();
-    result1 = 31 * result1 + result().hashCode();
+    //noinspection ConstantConditions
+    result1 = 31 * result1 + (result() != null ? result().hashCode() : 0);
     return result1;
   }
 }

--- a/app/src/main/java/com/felipecsl/elifut/models/converter/MatchConverter.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/converter/MatchConverter.java
@@ -45,10 +45,14 @@ public class MatchConverter extends Persistable.Converter<Match> {
   @Override public ContentValues toContentValues(Match match, ElifutDataStore service) {
     Persistable.Converter<MatchResult> converter =
         service.converterForType(AutoValueClasses.MATCH_RESULT);
-    return ContentValuesBuilder.create()
+    ContentValuesBuilder contentValuesBuilder = ContentValuesBuilder.create()
         .put("home_id", match.home().id())
-        .put("away_id", match.away().id())
-        .put(converter.toContentValues(match.result(), service))
-        .build();
+        .put("away_id", match.away().id());
+
+    if (match.result() != null) {
+      contentValuesBuilder.put(converter.toContentValues(match.result(), service));
+    }
+
+    return contentValuesBuilder.build();
   }
 }

--- a/app/src/main/java/com/felipecsl/elifut/models/converter/MatchResultConverter.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/converter/MatchResultConverter.java
@@ -34,10 +34,14 @@ public final class MatchResultConverter extends Persistable.Converter<MatchResul
 
   @Override public MatchResult fromCursor(SimpleCursor cursor, ElifutDataStore service) {
     try {
-      return adapter.fromJson(cursor.getString("result"));
+      String result = cursor.getString("result");
+      if (result != null) {
+        return adapter.fromJson(result);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+    return null;
   }
 
   @Override public ContentValues toContentValues(

--- a/app/src/main/java/com/felipecsl/elifut/preferences/LeagueDetails.java
+++ b/app/src/main/java/com/felipecsl/elifut/preferences/LeagueDetails.java
@@ -1,8 +1,14 @@
 package com.felipecsl.elifut.preferences;
 
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
 import com.felipecsl.elifut.AutoValueClasses;
+import com.felipecsl.elifut.match.MatchResultGenerator;
 import com.felipecsl.elifut.models.Club;
 import com.felipecsl.elifut.models.LeagueRound;
+import com.felipecsl.elifut.models.Match;
+import com.felipecsl.elifut.models.MatchResult;
 import com.felipecsl.elifut.services.ElifutDataStore;
 import com.felipecsl.elifut.services.LeagueRoundGenerator;
 
@@ -13,11 +19,13 @@ import rx.Observable;
 public final class LeagueDetails {
   private final ElifutDataStore service;
   private final LeagueRoundGenerator leagueRoundGenerator;
+  private final MatchResultGenerator generator;
 
   public LeagueDetails(ElifutDataStore persistenceService,
-      LeagueRoundGenerator leagueRoundGenerator) {
+      LeagueRoundGenerator leagueRoundGenerator, MatchResultGenerator generator) {
     this.service = persistenceService;
     this.leagueRoundGenerator = leagueRoundGenerator;
+    this.generator = generator;
   }
 
   /**
@@ -29,7 +37,7 @@ public final class LeagueDetails {
     service.create(leagueRoundGenerator.generateRounds(allClubs));
   }
 
-  /** Removes the next round from the list of upcoming rounds and returns it */
+  /** Removes the next round from the list of upcoming rounds and returns it. */
   public LeagueRound nextRound() {
     List<? extends LeagueRound> nextRounds = rounds();
     if (nextRounds == null || nextRounds.isEmpty()) {
@@ -39,6 +47,13 @@ public final class LeagueDetails {
     //noinspection ConstantConditions
     service.delete(nextRound, nextRound.id());
     return nextRound;
+  }
+
+  /** Adds MatchResults to the list of matches on the provided LeagueRound */
+  public LeagueRound executeRound(LeagueRound round) {
+    List<Match> matchesWithResult = FluentIterable.from(round.matches()).transform(m ->
+        Match.create(m.id(), m.home(), m.away(), generator.generate(m.home(), m.away()))).toList();
+    return LeagueRound.create(round.id(), round.roundNumber(), matchesWithResult);
   }
 
   public Observable<? extends List<? extends Club>> clubsObservable() {

--- a/app/src/main/java/com/felipecsl/elifut/services/LeagueRoundGenerator.java
+++ b/app/src/main/java/com/felipecsl/elifut/services/LeagueRoundGenerator.java
@@ -6,6 +6,7 @@ import com.felipecsl.elifut.match.MatchResultGenerator;
 import com.felipecsl.elifut.models.Club;
 import com.felipecsl.elifut.models.LeagueRound;
 import com.felipecsl.elifut.models.Match;
+
 import com.google.common.base.Preconditions;
 
 import java.util.Arrays;
@@ -16,14 +17,7 @@ import java.util.Map;
 import static com.felipecsl.elifut.util.CollectionUtils.shuffle;
 
 public class LeagueRoundGenerator {
-  private final MatchResultGenerator generator;
-
   public LeagueRoundGenerator() {
-    this(new MatchResultGenerator());
-  }
-
-  public LeagueRoundGenerator(MatchResultGenerator generator) {
-    this.generator = generator;
   }
 
   @VisibleForTesting List<LeagueRound> generateRoundsDeterministic(List<? extends Club> clubs) {
@@ -61,21 +55,22 @@ public class LeagueRoundGenerator {
         if (round % 2 == 0) {
           clubHome = clubMap.get(home + 1);
           clubAway = clubMap.get(away + 1);
-        }
-        else {
+        } else {
           clubHome = clubMap.get(away + 1);
           clubAway = clubMap.get(home + 1);
         }
 
-        Match newMatch = Match.create(clubHome, clubAway, generator.generate(clubHome, clubAway));
+        Match newMatch = Match.create(clubHome, clubAway);
         rounds[round].addMatch(newMatch);
       }
     }
 
-    return  Arrays.asList(rounds);
+    return Arrays.asList(rounds);
   }
 
-  /** Generates a random list of league rounds from the provided list of clubs. */
+  /**
+   * Generates a random list of league rounds from the provided list of clubs.
+   */
   public List<LeagueRound> generateRounds(List<? extends Club> clubs) {
     return generateRoundsDeterministic(shuffle(clubs));
   }

--- a/app/src/main/res/layout/fragment_team_squad.xml
+++ b/app/src/main/res/layout/fragment_team_squad.xml
@@ -1,50 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.NestedScrollView
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v4.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
   android:background="@drawable/player_card_background"
-  app:layout_behavior="@string/appbar_scrolling_view_behavior">
+  app:layout_behavior="@string/appbar_scrolling_view_behavior"
+  >
 
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
     android:orientation="vertical"
-    android:paddingTop="20dp">
+    android:paddingTop="20dp"
+    >
 
     <LinearLayout
       android:id="@+id/attackers"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:orientation="horizontal">
+      android:orientation="horizontal"
+      >
 
       <FrameLayout
         android:id="@+id/player_at1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:visibility="invisible"/>
+        android:visibility="invisible"
+        />
 
       <FrameLayout
         android:id="@+id/player_at2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_at3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_at4"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:visibility="invisible"/>
+        android:visibility="invisible"
+        />
 
     </LinearLayout>
 
@@ -53,33 +59,38 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal"
-      android:translationY="-10dp">
+      android:translationY="-10dp"
+      >
 
       <FrameLayout
         android:id="@+id/player_cm1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_cm2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_cm3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_cm4"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
     </LinearLayout>
 
@@ -88,33 +99,38 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="horizontal"
-      android:translationY="-20dp">
+      android:translationY="-20dp"
+      >
 
       <FrameLayout
         android:id="@+id/player_lb"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_cb1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_cb2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
       <FrameLayout
         android:id="@+id/player_rb"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        />
 
     </LinearLayout>
 
@@ -122,7 +138,8 @@
       android:id="@+id/player_gk"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:translationY="-20dp"/>
+      android:translationY="-20dp"
+      />
 
   </LinearLayout>
 </android.support.v4.widget.NestedScrollView>

--- a/app/src/test/java/com/felipecsl/elifut/models/converter/MatchConverterTest.java
+++ b/app/src/test/java/com/felipecsl/elifut/models/converter/MatchConverterTest.java
@@ -7,6 +7,7 @@ import com.felipecsl.elifut.BuildConfig;
 import com.felipecsl.elifut.ElifutTestRunner;
 import com.felipecsl.elifut.TestElifutApplication;
 import com.felipecsl.elifut.TestFixtures;
+import com.felipecsl.elifut.models.Club;
 import com.felipecsl.elifut.models.Goal;
 import com.felipecsl.elifut.models.Match;
 import com.felipecsl.elifut.models.MatchResult;
@@ -44,6 +45,15 @@ public class MatchConverterTest {
         .build(TestFixtures.GREMIO, TestFixtures.INTERNACIONAL);
     Match match = Match.create(TestFixtures.GREMIO, TestFixtures.INTERNACIONAL, matchResult);
     service.create(Arrays.asList(TestFixtures.GREMIO, TestFixtures.INTERNACIONAL));
+    service.create(match);
+    assertThat(service.query(AutoValueClasses.MATCH)).isEqualTo(Collections.singletonList(match));
+  }
+
+  @Test public void testMissingResult() {
+    Club gremio = TestFixtures.GREMIO;
+    Club internacional = TestFixtures.INTERNACIONAL;
+    Match match = Match.create(gremio, internacional);
+    service.create(Arrays.asList(gremio, internacional));
     service.create(match);
     assertThat(service.query(AutoValueClasses.MATCH)).isEqualTo(Collections.singletonList(match));
   }

--- a/app/src/test/java/com/felipecsl/elifut/services/LeagueRoundGeneratorTest.java
+++ b/app/src/test/java/com/felipecsl/elifut/services/LeagueRoundGeneratorTest.java
@@ -46,19 +46,14 @@ public class LeagueRoundGeneratorTest {
     Club internacional = TestFixtures.INTERNACIONAL;
     List<Club> clubs = Arrays.asList(gremio, internacional);
 
-    MatchResultGenerator generator = mock(MatchResultGenerator.class);
-    LeagueRoundGenerator roundGenerator = new LeagueRoundGenerator(generator);
-    MatchResult matchResult1 = MatchResult.builder().build(gremio, internacional);
-    MatchResult matchResult2 = MatchResult.builder().build(internacional, gremio);
-    when(generator.generate(gremio, internacional)).thenReturn(matchResult1);
-    when(generator.generate(internacional, gremio)).thenReturn(matchResult2);
+    LeagueRoundGenerator roundGenerator = new LeagueRoundGenerator();
 
     List<LeagueRound> leagueRounds = roundGenerator.generateRoundsDeterministic(clubs);
 
     assertThat(leagueRounds.size()).isEqualTo(2);
     assertThat(leagueRounds).isEqualTo(Arrays.asList(
-        LeagueRound.create(1, singletonList(Match.create(gremio, internacional, matchResult1))),
-        LeagueRound.create(2, singletonList(Match.create(internacional, gremio, matchResult2)))));
+        LeagueRound.create(1, singletonList(Match.create(gremio, internacional))),
+        LeagueRound.create(2, singletonList(Match.create(internacional, gremio)))));
   }
 
   @Test public void testGenerateRounds() {
@@ -73,10 +68,7 @@ public class LeagueRoundGeneratorTest {
     Club san = newClub("Santos");
     Club pal = newClub("Palmeiras");
     List<Club> clubs = Arrays.asList(gre, inter, fla, flu, sp, cor, atl, cru, san, pal);
-    MatchResultGenerator generator = mock(MatchResultGenerator.class);
-    LeagueRoundGenerator roundGenerator = new LeagueRoundGenerator(generator);
-    MatchResult matchResult = mock(MatchResult.class);
-    when(generator.generate(any(), any())).thenReturn(matchResult);
+    LeagueRoundGenerator roundGenerator = new LeagueRoundGenerator();
 
     List<LeagueRound> leagueRounds = roundGenerator.generateRounds(clubs);
 
@@ -84,8 +76,8 @@ public class LeagueRoundGeneratorTest {
 
     for (int i = 0; i < clubs.size(); i++) {
       for (int j = i + 1; j < clubs.size(); j++) {
-        allMatches.add(Match.create(clubs.get(i), clubs.get(j), matchResult));
-        allMatches.add(Match.create(clubs.get(j), clubs.get(i), matchResult));
+        allMatches.add(Match.create(clubs.get(i), clubs.get(j)));
+        allMatches.add(Match.create(clubs.get(j), clubs.get(i)));
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.5.0'
+    classpath 'com.android.tools.build:gradle:2.0.0-beta2'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.2.1'
     classpath 'me.tatarka:gradle-retrolambda:3.2.4'


### PR DESCRIPTION
There are many variables that should be taken into account when
calculating the MatchResult, so it did not make sense to calculate
them all at once at the start of the League. Also the user could change
players, and other variables during the League that could affect future
results. Even though this is not how it currently works, this is the
first step to make sure we can take those variables into account.