### PR TITLE
User Club squad rating to calculate MatchResult

### DIFF
--- a/app/src/main/java/com/felipecsl/elifut/DataModule.java
+++ b/app/src/main/java/com/felipecsl/elifut/DataModule.java
@@ -24,6 +24,7 @@ import com.felipecsl.elifut.models.converter.MatchResultConverter;
 import com.felipecsl.elifut.models.converter.PlayerConverter;
 import com.felipecsl.elifut.preferences.LeagueDetails;
 import com.felipecsl.elifut.preferences.UserPreferences;
+import com.felipecsl.elifut.services.ClubDataStore;
 import com.felipecsl.elifut.services.ElifutDataStore;
 import com.felipecsl.elifut.services.LeagueRoundGenerator;
 import com.squareup.moshi.Moshi;
@@ -85,13 +86,18 @@ public class DataModule {
     return new MatchResultGenerator();
   }
 
-  @Provides @Singleton LeagueDetails provideLeagueDetails(ElifutDataStore persistenceService,
-      LeagueRoundGenerator leagueRoundGenerator, MatchResultGenerator matchResultGenerator) {
-    return new LeagueDetails(persistenceService, leagueRoundGenerator, matchResultGenerator);
+  @Provides @Singleton LeagueDetails provideLeagueDetails(ClubDataStore clubDataStore,
+      LeagueRoundGenerator leagueRoundGenerator, MatchResultGenerator matchResultGenerator,
+      ElifutDataStore persistenceService) {
+    return new LeagueDetails(persistenceService, clubDataStore, leagueRoundGenerator,
+        matchResultGenerator);
   }
 
-  @Provides @Singleton ElifutDataStore provideElifutPersistenceService(
-      List<Persistable.Converter<?>> converters) {
+  @Provides @Singleton ClubDataStore provideClubDataStore(ElifutDataStore elifutDataStore) {
+    return new ClubDataStore(elifutDataStore);
+  }
+
+  @Provides @Singleton ElifutDataStore provideDataStore(List<Persistable.Converter<?>> converters) {
     return new ElifutDataStore(context, SqlBrite.create(), converters);
   }
 

--- a/app/src/main/java/com/felipecsl/elifut/activitiy/TeamPlayersActivity.java
+++ b/app/src/main/java/com/felipecsl/elifut/activitiy/TeamPlayersActivity.java
@@ -14,7 +14,7 @@ import com.felipecsl.elifut.R;
 import com.felipecsl.elifut.adapter.PlayersAdapter;
 import com.felipecsl.elifut.models.Club;
 import com.felipecsl.elifut.models.Player;
-import com.felipecsl.elifut.services.ElifutDataStore;
+import com.felipecsl.elifut.services.ClubDataStore;
 
 import java.util.ArrayList;
 
@@ -40,7 +40,7 @@ public class TeamPlayersActivity extends ElifutActivity implements PlayersAdapte
   @Bind(R.id.toolbar) Toolbar toolbar;
   @BindColor(R.color.color_primary) int colorPrimary;
 
-  @Inject ElifutDataStore dataStore;
+  @Inject ClubDataStore dataStore;
 
   @State Club club;
   @State Player previousPlayer;

--- a/app/src/main/java/com/felipecsl/elifut/fragment/TeamSquadFragment.java
+++ b/app/src/main/java/com/felipecsl/elifut/fragment/TeamSquadFragment.java
@@ -1,5 +1,8 @@
 package com.felipecsl.elifut.fragment;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -13,18 +16,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
-import com.felipecsl.elifut.AutoValueClasses;
 import com.felipecsl.elifut.R;
 import com.felipecsl.elifut.activitiy.PlayerDetailsActivity;
 import com.felipecsl.elifut.adapter.SmallPlayerViewHolder;
 import com.felipecsl.elifut.models.Club;
 import com.felipecsl.elifut.models.ClubSquad;
 import com.felipecsl.elifut.models.Player;
+import com.felipecsl.elifut.services.ClubDataStore;
 import com.felipecsl.elifut.services.ElifutDataStore;
 import com.felipecsl.elifut.util.FragmentBundler;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +41,7 @@ public class TeamSquadFragment extends ElifutFragment {
   private static final String TAG = "TeamSquadFragment";
 
   @Inject ElifutDataStore persistenceService;
+  @Inject ClubDataStore clubDataStore;
 
   @State Club club;
   @State ArrayList<Player> players;
@@ -65,11 +66,11 @@ public class TeamSquadFragment extends ElifutFragment {
     }
 
     @Override public void onError(Throwable e) {
-      Log.d(TAG, "Failed to load squad", e);
+      Log.d(TAG, "Failed to load players", e);
     }
 
     @Override public void onNext(ClubSquad clubSquad) {
-      players = new ArrayList<>(clubSquad.squad());
+      players = new ArrayList<>(clubSquad.players());
       onPlayersLoaded();
     }
   };
@@ -166,8 +167,7 @@ public class TeamSquadFragment extends ElifutFragment {
   }
 
   private void loadPlayers() {
-    persistenceService.observeOne(AutoValueClasses.CLUB_SQUAD, "club_id = ?",
-        String.valueOf(club.id())).subscribe(playersObserver);
+    clubDataStore.squadObservable(club).subscribe(playersObserver);
   }
 
   class SelectableSmallPlayerViewHolder extends SmallPlayerViewHolder {

--- a/app/src/main/java/com/felipecsl/elifut/models/ClubSquad.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/ClubSquad.java
@@ -1,8 +1,12 @@
 package com.felipecsl.elifut.models;
 
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.FluentIterable;
+
 import android.support.annotation.Nullable;
 
-import com.google.auto.value.AutoValue;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
 import java.util.List;
 
@@ -10,7 +14,7 @@ import java.util.List;
 public abstract class ClubSquad implements Persistable {
   @Nullable public abstract Integer id();
   public abstract int clubId();
-  public abstract List<Player> squad();
+  public abstract List<Player> players();
 
   public static ClubSquad create(int clubId, List<Player> squad) {
     return create(null, clubId, squad);
@@ -20,11 +24,23 @@ public abstract class ClubSquad implements Persistable {
     return new AutoValue_ClubSquad(id, clubId, squad);
   }
 
+  public double rating() {
+    List<Integer> ratings = FluentIterable.from(players()).transform(Player::rating).toList();
+    DescriptiveStatistics stats = new DescriptiveStatistics();
+    for (Integer rating : ratings) {
+      stats.addValue(rating);
+    }
+    double mean = stats.getMean();
+    double standardDeviation = stats.getStandardDeviation();
+    NormalDistribution normalDistribution = new NormalDistribution(mean, standardDeviation);
+    return normalDistribution.sample();
+  }
+
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder id(Integer x);
     public abstract Builder clubId(int x);
-    public abstract Builder squad(List<Player> x);
+    public abstract Builder players(List<Player> x);
     public abstract ClubSquad build();
   }
 

--- a/app/src/main/java/com/felipecsl/elifut/models/MatchResult.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/MatchResult.java
@@ -1,10 +1,11 @@
 package com.felipecsl.elifut.models;
 
+import com.google.auto.value.AutoValue;
+
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 
 import com.felipecsl.elifut.BuildConfig;
-import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
 
 import org.apache.commons.math3.distribution.NormalDistribution;
@@ -19,7 +20,7 @@ import rx.schedulers.Schedulers;
 @AutoValue
 public abstract class MatchResult implements Parcelable, Persistable {
   public static final float HOME_WIN_PROBABILITY = .465f;
-  public static final float DRAW_PROBABILITY = HOME_WIN_PROBABILITY + .174f;
+  public static final float DRAW_PROBABILITY = .174f;
   public static final NormalDistribution GOALS_DISTRIBUTION = new NormalDistribution(2.6, 1.7);
 
   @Nullable public abstract Club winner();

--- a/app/src/main/java/com/felipecsl/elifut/models/converter/ClubSquadConverter.java
+++ b/app/src/main/java/com/felipecsl/elifut/models/converter/ClubSquadConverter.java
@@ -45,7 +45,7 @@ public class ClubSquadConverter extends Persistable.Converter<ClubSquad> {
     return ContentValuesBuilder.create()
         .put("id", clubSquad.id())
         .put("club_id", clubSquad.clubId())
-        .put("player_ids", TextUtils.join(",", Lists.transform(clubSquad.squad(), Player::id)))
+        .put("player_ids", TextUtils.join(",", Lists.transform(clubSquad.players(), Player::id)))
         .build();
   }
 }

--- a/app/src/main/java/com/felipecsl/elifut/services/ClubDataStore.java
+++ b/app/src/main/java/com/felipecsl/elifut/services/ClubDataStore.java
@@ -1,0 +1,37 @@
+package com.felipecsl.elifut.services;
+
+import com.felipecsl.elifut.AutoValueClasses;
+import com.felipecsl.elifut.models.Club;
+import com.felipecsl.elifut.models.ClubSquad;
+import com.felipecsl.elifut.models.Player;
+
+import java.util.List;
+
+import rx.Observable;
+
+public class ClubDataStore {
+  private ElifutDataStore dataStore;
+
+  public ClubDataStore(ElifutDataStore dataStore) {
+    this.dataStore = dataStore;
+  }
+
+  public ClubSquad squad(Club club) {
+    String id = String.valueOf(club.id());
+    return dataStore.queryOne(AutoValueClasses.CLUB_SQUAD, "club_id = ?", id);
+  }
+
+  public List<? extends Player> allPlayers(Club club) {
+    String id = String.valueOf(club.id());
+    return dataStore.query(AutoValueClasses.PLAYER, "club_id = ?", id);
+  }
+
+  public void updateSquad(ClubSquad currentSquad, ClubSquad newSquad) {
+    dataStore.update(newSquad, currentSquad.id());
+  }
+
+  public Observable<? extends ClubSquad> squadObservable(Club club) {
+    String id = String.valueOf(club.id());
+    return dataStore.observeOne(AutoValueClasses.CLUB_SQUAD, "club_id = ?", id);
+  }
+}

--- a/app/src/main/java/com/felipecsl/elifut/services/ClubSquadBuilder.java
+++ b/app/src/main/java/com/felipecsl/elifut/services/ClubSquadBuilder.java
@@ -13,9 +13,9 @@ import java.util.List;
 
 /**
  * Generates a {@link ClubSquad} for the provided team based on the list of all the available
- * players for that team. The returned squad has exactly 11 players, including: 1 GK, 4 defenders,
+ * players for that team. The returned players has exactly 11 players, including: 1 GK, 4 defenders,
  * 4 midfielders and 2 attackers. It will try to use exactly 1 RB and 1 LB from the provided list.
- * If it can't find them, then other positions (CB) will be used to complete the squad.
+ * If it can't find them, then other positions (CB) will be used to complete the players.
  */
 public final class ClubSquadBuilder {
   private final Club club;

--- a/app/src/main/java/com/felipecsl/elifut/services/ElifutDataStore.java
+++ b/app/src/main/java/com/felipecsl/elifut/services/ElifutDataStore.java
@@ -1,5 +1,7 @@
 package com.felipecsl.elifut.services;
 
+import com.google.common.primitives.Ints;
+
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -9,9 +11,6 @@ import android.text.TextUtils;
 
 import com.felipecsl.elifut.SimpleCursor;
 import com.felipecsl.elifut.models.Persistable;
-
-import com.google.common.primitives.Ints;
-
 import com.squareup.sqlbrite.BriteDatabase;
 import com.squareup.sqlbrite.SqlBrite;
 

--- a/app/src/main/java/com/felipecsl/elifut/services/ElifutService.java
+++ b/app/src/main/java/com/felipecsl/elifut/services/ElifutService.java
@@ -17,7 +17,7 @@ public interface ElifutService {
   @GET("/players/{id}.json")
   Observable<Response<Player>> player(@Path("id") int id);
 
-  @GET("/players/squad.json")
+  @GET("/players/players.json")
   Observable<Response<List<Player>>> playersByClub(@Query("club_id") int clubId);
 
   @GET("/clubs/{id}.json")

--- a/app/src/test/java/com/felipecsl/elifut/models/ClubTest.java
+++ b/app/src/test/java/com/felipecsl/elifut/models/ClubTest.java
@@ -6,8 +6,8 @@ import com.felipecsl.elifut.BuildConfig;
 import com.felipecsl.elifut.ElifutTestRunner;
 import com.felipecsl.elifut.TestElifutApplication;
 import com.felipecsl.elifut.TestFixtures;
+import com.felipecsl.elifut.services.ClubDataStore;
 import com.felipecsl.elifut.services.ElifutDataStore;
-import com.squareup.sqlbrite.SqlBrite;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     manifest = ElifutTestRunner.MANIFEST_PATH)
 public class ClubTest {
   @Inject ElifutDataStore service;
+  @Inject ClubDataStore clubDataStore;
 
   @Before public void setUp() {
     TestElifutApplication application = (TestElifutApplication) RuntimeEnvironment.application;
@@ -83,7 +84,7 @@ public class ClubTest {
     ClubSquad clubSquad = ClubSquad.create(0, Collections.singletonList(gornaldo));
     service.create(players);
     service.create(clubSquad);
-    List<? extends Player> substitutes = club.substitutes(service);
+    List<? extends Player> substitutes = club.substitutes(clubDataStore);
     assertThat(substitutes).isEqualTo(Collections.singletonList(pele));
   }
 }

--- a/app/src/test/java/com/felipecsl/elifut/services/ClubSquadBuilderTest.java
+++ b/app/src/test/java/com/felipecsl/elifut/services/ClubSquadBuilderTest.java
@@ -88,7 +88,7 @@ public class ClubSquadBuilderTest {
 
     ClubSquad clubSquad = builder.build();
 
-    assertThat(clubSquad.squad()).containsExactly(buildPlayer("GK"), buildPlayer("LB"),
+    assertThat(clubSquad.players()).containsExactly(buildPlayer("GK"), buildPlayer("LB"),
         buildPlayer("CB"), buildPlayer("CB"), buildPlayer("RB"), buildPlayer("LM"),
         buildPlayer("CM"), buildPlayer("CAM"), buildPlayer("CDM"), buildPlayer("ST"),
         buildPlayer("CF"));
@@ -103,7 +103,7 @@ public class ClubSquadBuilderTest {
 
     ClubSquad clubSquad = builder.build();
 
-    assertThat(clubSquad.squad()).containsExactly(buildPlayer("GK"), buildPlayer("LB"),
+    assertThat(clubSquad.players()).containsExactly(buildPlayer("GK"), buildPlayer("LB"),
         buildPlayer("CB"), buildPlayer("CB"), buildPlayer("RB"), buildPlayer("LM"),
         buildPlayer("CM"), buildPlayer("CAM"), buildPlayer("CDM"), buildPlayer("ST"),
         buildPlayer("CF"));


### PR DESCRIPTION
This uses `ClubSquad.rating()` to calculate a team rating for the
squad that can be used to affect the odds of winning/losing a
match. The rating takes into account the squad mean rating and
standard deviation and uses a normal distribution to sample a
random rating.
This is then fed into the `MatchResultGenerator` to aid on the
random result calculation. The rating difference between home
and away is used to calculate the odds.
Also created `ClubDataStore` to help easily query data related
to clubs from `ElifutDataStore`.